### PR TITLE
Added 'ago' and 'till' pipe and the required format pipes

### DIFF
--- a/examples/label.html
+++ b/examples/label.html
@@ -104,7 +104,7 @@
       <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%DDd','upper')"></ftui-label>
     </ftui-grid-tile>
 
-    <ftui-grid-tile row="4" col="4" height="2" width="1">
+    <ftui-grid-tile row="4" col="4" height="1" width="1">
       <header>text-filter regexec</header>
       <ftui-label [text]="AgroWeather:state | part('.*T:(.*)H:.*')"></ftui-label>
     </ftui-grid-tile>

--- a/examples/label.html
+++ b/examples/label.html
@@ -80,7 +80,31 @@
       <ftui-label [text]="AgroWeather:state | part(4) | toInt() | multiply(2) | round(1) "></ftui-label>
     </ftui-grid-tile>
 
-    <ftui-grid-tile row="4" col="4" height="1" width="1">
+    <ftui-grid-tile row="3" col="5" height="2" width="2" shape="round">
+      <header>ago ...</header>
+      <ftui-label [text]="ftuitest:dateTime4ago"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago()"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('[ dd.hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('[ elapsed since dd days + hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('ssssssss seconds')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('mmmmmm minutes')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('hhhh hours')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('dd days')"></ftui-label>
+    </ftui-grid-tile>
+
+    <ftui-grid-tile row="3" col="7" height="2" width="2" shape="round">
+      <header>... till</header>
+      <ftui-label [text]="ftuitest:dateTime4till"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till()"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('[ dd.hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('[ still dd days + hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%SSSSSSSSs','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%MMMMMMm','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%HHHHh','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%DDd','upper')"></ftui-label>
+    </ftui-grid-tile>
+
+    <ftui-grid-tile row="4" col="4" height="2" width="1">
       <header>text-filter regexec</header>
       <ftui-label [text]="AgroWeather:state | part('.*T:(.*)H:.*')"></ftui-label>
     </ftui-grid-tile>

--- a/examples/label.html
+++ b/examples/label.html
@@ -84,24 +84,36 @@
       <header>ago ...</header>
       <ftui-label [text]="ftuitest:dateTime4ago"></ftui-label>
       <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago()"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('[ dd.hh:mm:ss ]')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('[ elapsed since dd days + hh:mm:ss ]')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('ssssssss seconds')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('mmmmmm minutes')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('hhhh hours')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | agoFormat('dd days')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('[ dd.hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('[ elapsed since dd days + hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('ssssssss seconds')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('mmmmmm minutes')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('hhhh hours')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4ago | toDate() | ago() | timeFormat('dd days')"></ftui-label>
     </ftui-grid-tile>
 
     <ftui-grid-tile row="3" col="7" height="2" width="2" shape="round">
       <header>... till</header>
       <ftui-label [text]="ftuitest:dateTime4till"></ftui-label>
       <ftui-label [text]="ftuitest:dateTime4till | toDate() | till()"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('[ dd.hh:mm:ss ]')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('[ still dd days + hh:mm:ss ]')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%SSSSSSSSs','upper')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%MMMMMMm','upper')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%HHHHh','upper')"></ftui-label>
-      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | tillFormat('%DDd','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('[ dd.hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('[ still dd days + hh:mm:ss ]')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('%SSSSSSSSs','ms','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('%MMMMMMm','ms','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('%HHHHh','ms','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:dateTime4till | toDate() | till() | timeFormat('%DDd','ms','upper')"></ftui-label>
+    </ftui-grid-tile>
+
+    <ftui-grid-tile row="3" col="9" height="2" width="2" shape="round">
+      <header>... till</header>
+      <ftui-label [text]="ftuitest:seconds4timeFormat"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('[ dd.hh:mm:ss ]','s')"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('[ dd day(s) + hh:mm:ss ]','s')"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('%SSSSSSSSs','s','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('%MMMMMMm','s','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('%HHHHh','s','upper')"></ftui-label>
+      <ftui-label [text]="ftuitest:seconds4timeFormat | timeFormat('%DDd','s','upper')"></ftui-label>
     </ftui-grid-tile>
 
     <ftui-grid-tile row="4" col="4" height="1" width="1">

--- a/modules/ftui/ftui.binding.js
+++ b/modules/ftui/ftui.binding.js
@@ -241,6 +241,10 @@ export class FtuiBinding {
       const multiply = value => input => input * value;
       const replace = (find, replace) => input => String(input).replace(find, replace);
       const map = value => input => ftuiHelper.getMatchingValue(parseHocon(value, true), input);
+      const ago = () => input => ftuiHelper.dateAgo(input);
+      const agoFormat = (format,mode='lower') => input => ftuiHelper.agoTillFormat(input, format, mode);
+      const till = () => input => ftuiHelper.dateTill(input);
+      const tillFormat = (format,mode='lower') => input => ftuiHelper.agoTillFormat(input, format, mode);
 
       const pipe = (f1, ...fns) => (...args) => {
         return fns.reduce((res, fn) => fn(res), f1.apply(null, args));

--- a/modules/ftui/ftui.binding.js
+++ b/modules/ftui/ftui.binding.js
@@ -16,7 +16,7 @@ const map = value => input => ftuiHelper.getMatchingValue(parseHocon(value, true
 const scale = (minIn, maxIn, minOut, maxOut) => input => ftuiHelper.scale(input, minIn, maxIn, minOut, maxOut);
 const ago = () => input => ftuiHelper.dateAgo(input);
 const till = () => input => ftuiHelper.dateTill(input);
-const timeFormat = (format,imode='ms',fmode='lower') => input => ftuiHelper.timeFormat(input, format, imode, fmode);
+const timeFormat = (format,inputMode='ms',formatMode='lower') => input => ftuiHelper.timeFormat(input, format, inputMode, formatMode);
 
 const pipe = (f1, ...fns) => (...args) => {
   return fns.reduce((res, fn) => fn(res), f1.apply(null, args));

--- a/modules/ftui/ftui.binding.js
+++ b/modules/ftui/ftui.binding.js
@@ -83,7 +83,7 @@ export class FtuiBinding {
       const filteredValue = this.filter(attributeValue, options.filter);
       const value = String(options.value).replace(/\$value/g, filteredValue);
       const [parameterId, deviceName, readingName] = ftuiHelper.parseReadingId(readingId);
-      console.log(options.cmd + '#' + deviceName+ '#' + readingName+ '#' + value)
+      console.log(options.cmd + '#' + deviceName + '#' + readingName + '#' + value)
       const cmdLine = [options.cmd, deviceName, readingName, value].join(' ');
 
       // update storage
@@ -241,10 +241,10 @@ export class FtuiBinding {
       const multiply = value => input => input * value;
       const replace = (find, replace) => input => String(input).replace(find, replace);
       const map = value => input => ftuiHelper.getMatchingValue(parseHocon(value, true), input);
+      const scale = (minIn, maxIn, minOut, maxOut) => input => ftuiHelper.scale(input, minIn, maxIn, minOut, maxOut);
       const ago = () => input => ftuiHelper.dateAgo(input);
-      const agoFormat = (format,mode='lower') => input => ftuiHelper.agoTillFormat(input, format, mode);
       const till = () => input => ftuiHelper.dateTill(input);
-      const tillFormat = (format,mode='lower') => input => ftuiHelper.agoTillFormat(input, format, mode);
+      const timeFormat = (format,imode='ms',fmode='lower') => input => ftuiHelper.timeFormat(input, format, imode, fmode);
 
       const pipe = (f1, ...fns) => (...args) => {
         return fns.reduce((res, fn) => fn(res), f1.apply(null, args));

--- a/modules/ftui/ftui.binding.js
+++ b/modules/ftui/ftui.binding.js
@@ -1,7 +1,26 @@
-import { parseHocon } from '../hocon/hocon.min.js';
 import * as ftuiHelper from './ftui.helper.js';
 import { fhemService } from './fhem.service.js';
+import { parseHocon } from '../hocon/hocon.min.js';
 
+/* eslint-disable no-unused-vars */
+const part = value => input => ftuiHelper.getPart(input, value);
+const toDate = value => input => ftuiHelper.dateFromString(input, value);
+const toBool = () => input => ftuiHelper.toBool(input);
+const toInt = () => input => parseInt(input, 10);
+const format = value => input => ftuiHelper.dateFormat(input, value);
+const round = value => input => ftuiHelper.round(input, value);
+const add = value => input => input + value;
+const multiply = value => input => input * value;
+const replace = (find, replace) => input => String(input).replace(find, replace);
+const map = value => input => ftuiHelper.getMatchingValue(parseHocon(value, true), input);
+const scale = (minIn, maxIn, minOut, maxOut) => input => ftuiHelper.scale(input, minIn, maxIn, minOut, maxOut);
+const ago = () => input => ftuiHelper.dateAgo(input);
+const till = () => input => ftuiHelper.dateTill(input);
+const timeFormat = (format,imode='ms',fmode='lower') => input => ftuiHelper.timeFormat(input, format, imode, fmode);
+
+const pipe = (f1, ...fns) => (...args) => {
+  return fns.reduce((res, fn) => fn(res), f1.apply(null, args));
+};
 
 export class FtuiBinding {
 
@@ -230,25 +249,6 @@ export class FtuiBinding {
 
   filter(text, filter = '') {
     if (filter !== '') {
-      /* eslint-disable no-unused-vars */
-      const part = value => input => ftuiHelper.getPart(input, value);
-      const toDate = value => input => ftuiHelper.dateFromString(input, value);
-      const toBool = () => input => ftuiHelper.toBool(input);
-      const toInt = () => input => parseInt(input, 10);
-      const format = value => input => ftuiHelper.dateFormat(input, value);
-      const round = value => input => ftuiHelper.round(input, value);
-      const add = value => input => input + value;
-      const multiply = value => input => input * value;
-      const replace = (find, replace) => input => String(input).replace(find, replace);
-      const map = value => input => ftuiHelper.getMatchingValue(parseHocon(value, true), input);
-      const scale = (minIn, maxIn, minOut, maxOut) => input => ftuiHelper.scale(input, minIn, maxIn, minOut, maxOut);
-      const ago = () => input => ftuiHelper.dateAgo(input);
-      const till = () => input => ftuiHelper.dateTill(input);
-      const timeFormat = (format,imode='ms',fmode='lower') => input => ftuiHelper.timeFormat(input, format, imode, fmode);
-
-      const pipe = (f1, ...fns) => (...args) => {
-        return fns.reduce((res, fn) => fn(res), f1.apply(null, args));
-      };
       try {
         const pipeNotInQuotes = /\|(?=([^']*'[^']*')*[^']*$)/g;
         filter = filter.replace(pipeNotInQuotes, ',').replace(/`/g, '"').replace(/´/g, '"');

--- a/modules/ftui/ftui.binding.js
+++ b/modules/ftui/ftui.binding.js
@@ -102,7 +102,6 @@ export class FtuiBinding {
       const filteredValue = this.filter(attributeValue, options.filter);
       const value = String(options.value).replace(/\$value/g, filteredValue);
       const [parameterId, deviceName, readingName] = ftuiHelper.parseReadingId(readingId);
-      console.log(options.cmd + '#' + deviceName + '#' + readingName + '#' + value)
       const cmdLine = [options.cmd, deviceName, readingName, value].join(' ');
 
       // update storage

--- a/modules/ftui/ftui.helper.js
+++ b/modules/ftui/ftui.helper.js
@@ -184,7 +184,7 @@ export function dateFormat(date, format, lang = 'de') {
   const eeee = (lang === 'de') ? weekday_de[d] : weekday[d];
   const eee = eeee.substr(0, 3);
   const ee = eeee.substr(0, 2);
-  let ret = format;
+  let ret = String(format);
   ret = ret.replace('DD', (dd > 9) ? dd : '0' + dd);
   ret = ret.replace('D', dd);
   ret = ret.replace('MM', (MM > 9) ? MM : '0' + MM);
@@ -200,7 +200,6 @@ export function dateFormat(date, format, lang = 'de') {
   ret = ret.replace('eeee', eeee);
   ret = ret.replace('eee', eee);
   ret = ret.replace('ee', ee);
-
   return ret;
 }
 
@@ -215,8 +214,8 @@ export function diffSeconds(date1, date2) {
 }
 
 export function durationFromSeconds(time) {
-  const hrs = Math.floor(time / 3600);
-  const mins = Math.floor((time % 3600) / 60);
+  const hrs = ~~(time / 3600);
+  const mins = ~~((time % 3600) / 60);
   const secs = time % 60;
   let ret = '';
   if (hrs > 0) {
@@ -227,22 +226,25 @@ export function durationFromSeconds(time) {
   return ret;
 }
 
-export function agoTillFormat(ms, format, mode='lower') {
-  var x = ms / 1000;
+export function timeFormat(ms, format, imode='ms', fmode='lower') {
+  // imode: 'ms' or 's'
+  let x = ms
+  if (imode == 'ms') { x /= 1000; }
 
-  var SECONDS = Math.floor(x);
-  var seconds = Math.floor(x % 60);
+  const SECONDS = ~~(x);
+  const seconds = ~~(x % 60);
   x /= 60;
-  var MINUTES = Math.floor(x);
-  var minutes = Math.floor(x % 60);
+  const MINUTES = ~~(x);
+  const minutes = ~~(x % 60);
   x /= 60;
-  var HOURS = Math.floor(x);
-  var hours = Math.floor(x % 24);
+  const HOURS = ~~(x);
+  const hours = ~~(x % 24);
   x /= 24;
-  var DAYS = Math.floor(x);
+  const DAYS = ~~(x);
 
-  let ret = format;
-  if (mode == 'lower') {
+  // fmode: 'lower' or 'upper'
+  let ret = String(format);
+  if (fmode == 'lower') {
     ret = ret.replace(/(^|[^a-z])(ssssssss)([^a-z]|$)/g, "$1%SSSSSSSS$3");
     ret = ret.replace(/(^|[^a-z])(mmmmmm)([^a-z]|$)/g, "$1%MMMMMM$3");
     ret = ret.replace(/(^|[^a-z])(hhhh)([^a-z]|$)/g, "$1%HHHH$3");
@@ -269,18 +271,20 @@ export function agoTillFormat(ms, format, mode='lower') {
 }
 
 export function dateAgo (date) {
-  var now = new Date();
-  var ms = (now - date);
+  const now = new Date();
+  const ms = (now - date);
 
   return ms;
 };
 
 export function dateTill (date) {
-  var now = new Date();
-  var ms = (date - now);
+  const now = new Date();
+  const ms = (date - now);
 
   return ms;
 };
+
+// Math functions
 
 export function round(number, precision) {
   const shift = (number, precision, reverseShift) => {
@@ -291,6 +295,12 @@ export function round(number, precision) {
     return +(numArray[0] + 'e' + (numArray[1] ? (+numArray[1] + precision) : precision));
   };
   return shift(Math.round(shift(number, precision, false)), precision, true);
+}
+
+export function scale(value, minIn, maxIn, minOut, maxOut) {
+  const slope = (minOut - maxOut) / (minIn - maxIn);
+  const intercept = slope * -(minIn) + minOut;
+  return value * slope + intercept;
 }
 
 export function debounce(callback, context = this) {

--- a/modules/ftui/ftui.helper.js
+++ b/modules/ftui/ftui.helper.js
@@ -226,25 +226,25 @@ export function durationFromSeconds(time) {
   return ret;
 }
 
-export function timeFormat(ms, format, imode='ms', fmode='lower') {
+export function timeFormat(ms, format, inputMode='ms', formatMode='lower') {
   // imode: 'ms' or 's'
   let x = ms
-  if (imode == 'ms') { x /= 1000; }
+  if (inputMode === 'ms') { x /= 1000; }
 
-  const SECONDS = ~~(x);
+  const totalSeconds = ~~(x);
   const seconds = ~~(x % 60);
   x /= 60;
-  const MINUTES = ~~(x);
+  const totalMinutes = ~~(x);
   const minutes = ~~(x % 60);
   x /= 60;
-  const HOURS = ~~(x);
+  const totalHours = ~~(x);
   const hours = ~~(x % 24);
   x /= 24;
-  const DAYS = ~~(x);
+  const totalDays = ~~(x);
 
   // fmode: 'lower' or 'upper'
   let ret = String(format);
-  if (fmode == 'lower') {
+  if (formatMode === 'lower') {
     ret = ret.replace(/(^|[^a-z])(ssssssss)([^a-z]|$)/g, "$1%SSSSSSSS$3");
     ret = ret.replace(/(^|[^a-z])(mmmmmm)([^a-z]|$)/g, "$1%MMMMMM$3");
     ret = ret.replace(/(^|[^a-z])(hhhh)([^a-z]|$)/g, "$1%HHHH$3");
@@ -256,10 +256,10 @@ export function timeFormat(ms, format, imode='ms', fmode='lower') {
     ret = ret.replace(/(^|[^a-z])(m)([^a-z]|$)/g, "$1%M$3");
     ret = ret.replace(/(^|[^a-z])(s)([^a-z]|$)/g, "$1%S$3");
   }
-  ret = ret.replace(/%SSSSSSSS/g, SECONDS);
-  ret = ret.replace(/%MMMMMM/g, MINUTES);
-  ret = ret.replace(/%HHHH/g, HOURS);
-  ret = ret.replace(/%DD/g, DAYS);
+  ret = ret.replace(/%SSSSSSSS/g, totalSeconds);
+  ret = ret.replace(/%MMMMMM/g, totalMinutes);
+  ret = ret.replace(/%HHHH/g, totalHours);
+  ret = ret.replace(/%DD/g, totalDays);
   ret = ret.replace(/%HH/g, (hours > 9) ? hours : '0' + hours);
   ret = ret.replace(/%MM/g, (minutes > 9) ? minutes : '0' + minutes);
   ret = ret.replace(/%SS/g, (seconds > 9) ? seconds : '0' + seconds);

--- a/modules/ftui/ftui.helper.js
+++ b/modules/ftui/ftui.helper.js
@@ -227,6 +227,61 @@ export function durationFromSeconds(time) {
   return ret;
 }
 
+export function agoTillFormat(ms, format, mode='lower') {
+  var x = ms / 1000;
+
+  var SECONDS = Math.floor(x);
+  var seconds = Math.floor(x % 60);
+  x /= 60;
+  var MINUTES = Math.floor(x);
+  var minutes = Math.floor(x % 60);
+  x /= 60;
+  var HOURS = Math.floor(x);
+  var hours = Math.floor(x % 24);
+  x /= 24;
+  var DAYS = Math.floor(x);
+
+  let ret = format;
+  if (mode == 'lower') {
+    ret = ret.replace(/(^|[^a-z])(ssssssss)([^a-z]|$)/g, "$1%SSSSSSSS$3");
+    ret = ret.replace(/(^|[^a-z])(mmmmmm)([^a-z]|$)/g, "$1%MMMMMM$3");
+    ret = ret.replace(/(^|[^a-z])(hhhh)([^a-z]|$)/g, "$1%HHHH$3");
+    ret = ret.replace(/(^|[^a-z])(dd)([^a-z]|$)/g, "$1%DD$3");
+    ret = ret.replace(/(^|[^a-z])(hh)([^a-z]|$)/g, "$1%HH$3");
+    ret = ret.replace(/(^|[^a-z])(mm)([^a-z]|$)/g, "$1%MM$3");
+    ret = ret.replace(/(^|[^a-z])(ss)([^a-z]|$)/g, "$1%SS$3");
+    ret = ret.replace(/(^|[^a-z])(h)([^a-z]|$)/g, "$1%H$3");
+    ret = ret.replace(/(^|[^a-z])(m)([^a-z]|$)/g, "$1%M$3");
+    ret = ret.replace(/(^|[^a-z])(s)([^a-z]|$)/g, "$1%S$3");
+  }
+  ret = ret.replace(/%SSSSSSSS/g, SECONDS);
+  ret = ret.replace(/%MMMMMM/g, MINUTES);
+  ret = ret.replace(/%HHHH/g, HOURS);
+  ret = ret.replace(/%DD/g, DAYS);
+  ret = ret.replace(/%HH/g, (hours > 9) ? hours : '0' + hours);
+  ret = ret.replace(/%MM/g, (minutes > 9) ? minutes : '0' + minutes);
+  ret = ret.replace(/%SS/g, (seconds > 9) ? seconds : '0' + seconds);
+  ret = ret.replace(/%H/g, hours);
+  ret = ret.replace(/%M/g, minutes);
+  ret = ret.replace(/%S/g, seconds);
+
+  return ret;
+}
+
+export function dateAgo (date) {
+  var now = new Date();
+  var ms = (now - date);
+
+  return ms;
+};
+
+export function dateTill (date) {
+  var now = new Date();
+  var ms = (date - now);
+
+  return ms;
+};
+
 export function round(number, precision) {
   const shift = (number, precision, reverseShift) => {
     if (reverseShift) {

--- a/modules/ftui/ftui.helper.js
+++ b/modules/ftui/ftui.helper.js
@@ -227,7 +227,7 @@ export function durationFromSeconds(time) {
 }
 
 export function timeFormat(ms, format, inputMode='ms', formatMode='lower') {
-  // imode: 'ms' or 's'
+  // inputMode: 'ms' or 's'
   let x = ms
   if (inputMode === 'ms') { x /= 1000; }
 
@@ -242,7 +242,7 @@ export function timeFormat(ms, format, inputMode='ms', formatMode='lower') {
   x /= 24;
   const totalDays = ~~(x);
 
-  // fmode: 'lower' or 'upper'
+  // formatMode: 'lower' or 'upper'
   let ret = String(format);
   if (formatMode === 'lower') {
     ret = ret.replace(/(^|[^a-z])(ssssssss)([^a-z]|$)/g, "$1%SSSSSSSS$3");


### PR DESCRIPTION
- 'ago' calcs the elapsed time since a dateTime value.
- 'till' calcs the time to reach a dateTime value.
- 'timeFormat' allows to format a time - given in seconds ('s') or milliseconds (',s').
- 'dd' means total days for the calculated time.
- 'hhhh' means total hours for the calculated time; 'hh' and 'h' means the hours for the remaining time of a day.
- 'mmmmmm' means total minutes for the calculated time; 'mm' and 'm' means the minutes for the remaining time of a hour.
- 'ssssssss' means total seconds for the calculated time; 'ss' and s' means the seconds for the remaining time of a minute.
- two replacement modes ('lower' and 'upper') allow to control the replacement process.
