### PR TITLE
Translated Chart-Controls units

### DIFF
--- a/components/chart/chart-controls.component.js
+++ b/components/chart/chart-controls.component.js
@@ -43,11 +43,11 @@ export class FtuiChartControls extends FtuiElement {
           <span id="forward">▶</span>
         </div>
         <div id="units">
-          <span class="unit" id="year">Year</span>
-          <span class="unit" id="month">Month</span>
-          <span class="unit" id="week">Week</span>
-          <span class="unit" id="day">Day</span>
-          <span class="unit" id="hour">Hour</span>
+          <span class="unit" id="year">Jahr</span>
+          <span class="unit" id="month">Monat</span>
+          <span class="unit" id="week">Woche</span>
+          <span class="unit" id="day">Tag</span>
+          <span class="unit" id="hour">Stunde</span>
         </div>
       </div>`;
   }


### PR DESCRIPTION
As the dates are also in german, using german time units as well might be the best user experience as long as there's no language tag / translation feature for the chart component.