### PR TITLE
NEW: label -  only display unit if text isn't empty

### DIFF
--- a/www/ftui/components/label/label.component.js
+++ b/www/ftui/components/label/label.component.js
@@ -16,6 +16,7 @@ export class FtuiLabel extends FtuiElement {
     super(Object.assign(FtuiLabel.properties, properties));
 
     this.mainSlotElement = this.shadowRoot.querySelector('slot[name="content"]');
+    this.unitSlotElement = this.shadowRoot.querySelector('slot[name="unit"]');
   }
 
   template() {
@@ -32,7 +33,7 @@ export class FtuiLabel extends FtuiElement {
           line-height: 0.8em;
         }
       </style>
-      <slot name="start"></slot><slot></slot><slot name="content"></slot><slot name="end">${this.unit}</slot>`;
+      <slot name="start"></slot><slot></slot><slot name="content"></slot><slot name="unit"></slot>`;
   }
 
   static get properties() {
@@ -55,6 +56,12 @@ export class FtuiLabel extends FtuiElement {
     switch (name) {
       case 'text':
         this.mainSlotElement.innerHTML = this.text;
+        if (this.unitSlotElement) {        
+          this.unitSlotElement.innerHTML = this.unit;
+          if (this.text.length==0) {
+            this.unitSlotElement.innerHTML = '';
+          }
+        }
         this.checkInterval();
         break;
       case 'interval':


### PR DESCRIPTION
Only display the unit by label if the text of the label isn't empty.