### PR TITLE
Use unit instead of span in weather example

### DIFF
--- a/www/ftui/examples/weather.html
+++ b/www/ftui/examples/weather.html
@@ -53,37 +53,37 @@
           <label>Heute</label>
           <ftui-weather size="4" [condition]="AgroWeather:fc0_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc0_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc0_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc0_tempMax" unit="°C"></ftui-label>
         </ftui-column>
         <ftui-column>
           <label>Morgen</label>
           <ftui-weather size="4" [condition]="AgroWeather:fc1_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc1_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc1_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc1_tempMax" unit="°C"></ftui-label>
         </ftui-column>
         <ftui-column>
           <ftui-label [text]="AgroWeather:fc2_date | toDate() | format('eeee')"></ftui-label>
           <ftui-weather size="4" [condition]="AgroWeather:fc2_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc2_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc2_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc2_tempMax" unit="°C"></ftui-label>
         </ftui-column>
         <ftui-column>
           <ftui-label [text]="AgroWeather:fc3_date | toDate() | format('eeee')"></ftui-label>
           <ftui-weather size="4" [condition]="AgroWeather:fc3_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc3_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc3_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc3_tempMax" unit="°C"></ftui-label>
         </ftui-column>
         <ftui-column>
           <ftui-label [text]="AgroWeather:fc4_date | toDate() | format('eeee')"></ftui-label>
           <ftui-weather size="4" [condition]="AgroWeather:fc4_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc4_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc4_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc4_tempMax" unit="°C"></ftui-label>
         </ftui-column>
         <ftui-column>
           <ftui-label [text]="AgroWeather:fc5_date | toDate() | format('eeee')"></ftui-label>
           <ftui-weather size="4" [condition]="AgroWeather:fc5_weatherDay"></ftui-weather>
           <ftui-label [text]="AgroWeather:fc5_weatherDay"></ftui-label>
-          <ftui-label [text]="AgroWeather:fc5_tempMax"><span slot="end">°C</span></ftui-label>
+          <ftui-label [text]="AgroWeather:fc5_tempMax" unit="°C"></ftui-label>
         </ftui-column>
       </ftui-row>
     </ftui-grid-tile>


### PR DESCRIPTION
- Current example uses <span slot="end>
  - At least Vivaldi (Chrome-Engine) does not display the unit then
  - Documentation suggest to use "unit" instead, this does work