### PR TITLE
NEW: binding pad - Füllzeichen

### DIFF
--- a/www/ftui/modules/ftui/ftui.binding.js
+++ b/www/ftui/modules/ftui/ftui.binding.js
@@ -28,6 +28,7 @@ const minusBlue = (value = 0) => input => Number(input) < value ? 'blue' : null;
 const contains = value => input => String(input).indexOf(value) < 0 ? true : false;
 const is = value => input => String(input) === value ? true : false;
 const isNot = value => input => String(input) !== value ? true : false;
+const pad = (cnt, char) => input => String(input).padStart(cnt, char);
 
 const pipe = (f1, ...fns) => (...args) => {
   return fns.reduce((res, fn) => fn(res), f1.apply(null, args));


### PR DESCRIPTION
z.B. | pad(2,'0') für führende Null 01, etc