### PR TITLE
Make FtuiGridTile ready to be subclassed

### DIFF
--- a/www/ftui/components/grid/grid-tile.component.js
+++ b/www/ftui/components/grid/grid-tile.component.js
@@ -11,15 +11,8 @@ import { FtuiElement } from '../element.component.js';
 
 export class FtuiGridTile extends FtuiElement {
 
-  constructor() {
-    const properties = {
-      row: 0,
-      col: 0,
-      height: 0,
-      width: 0,
-      color: '',
-    };
-    super(properties);
+  constructor(properties) {
+    super(Object.assign(FtuiGridTile.properties, properties));
 
     const header = this.querySelector('header, ftui-grid-header');
     header && header.setAttribute('slot', 'header');
@@ -31,6 +24,20 @@ export class FtuiGridTile extends FtuiElement {
     <div class="content">
       <slot></slot>
     </div>`;
+  }
+
+  static get properties() {
+    return {
+      row: 0,
+      col: 0,
+      height: 0,
+      width: 0,
+      color: ''
+    };
+  }
+
+  static get observedAttributes() {
+    return [...this.convertToAttributes(FtuiGridTile.properties), ...super.observedAttributes];
   }
 }
 

--- a/www/ftui/components/grid/grid.component.js
+++ b/www/ftui/components/grid/grid.component.js
@@ -29,7 +29,7 @@ export class FtuiGrid extends FtuiElement {
     this.debouncedResize = debounce(this.configureGrid, this);
 
     this.windowWidth = 0;
-    this.tiles = this.querySelectorAll('ftui-grid-tile');
+    this.tiles = this.querySelectorAll('ftui-grid-tile, .ftui-grid-tile');
 
 
     if (this.responsive) {


### PR DESCRIPTION
I want to able to subclass FtuiGridTile.
Change in grid-tile.component.js makes it subclassable (like with other classes in FTUI3).
Change in grid.component.js makes the subclassed tiles 'visible' to the grid logic. This is achieved by also looking for elements which also are of (CSS) class 'ftui-grid-tile'. By setting this (CSS) class in the derived (element) class, its getting visible to all the grid logic.
Both changes should be fully compatible with the existing code.

Rational: I'd like to create a number of 'ready-to-use' complex tiles, e.g. a ThermostatTile where other FTUI elements are automatically created in turn.

Please be a little bit patient, I'll release all those tiles on Github.