### PR TITLE
Absolute path fixes

### DIFF
--- a/www/ftui/components/button/button.component.js
+++ b/www/ftui/components/button/button.component.js
@@ -8,8 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import * as ftui from '../../modules/ftui/ftui.helper.js';
-
+import { getLocalCssPath, isEqual } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiButton extends FtuiElement {
   constructor(properties) {
@@ -26,7 +25,7 @@ export class FtuiButton extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/button/button.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <span class="button-inner">
         <slot></slot>
       </span>
@@ -65,7 +64,7 @@ export class FtuiButton extends FtuiElement {
 
   getNextValue() {
     const states = String(this.states).split(/[;,:]/).map(item => item.trim());
-    let currentIndex = states.findIndex((pattern) => ftui.isEqual(pattern, this.value));
+    let currentIndex = states.findIndex((pattern) => isEqual(pattern, this.value));
     // increase the index to the next value in the array of possible values
     currentIndex = ++currentIndex % states.length;
     return states[currentIndex].replace('$value', this.value );

--- a/www/ftui/components/chart/chart-controls.component.js
+++ b/www/ftui/components/chart/chart-controls.component.js
@@ -9,7 +9,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import * as ftuiHelper from '../../modules/ftui/ftui.helper.js';
+import { triggerEvent, getLocalCssPath, dateFormat, dateFromString } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiChartControls extends FtuiElement {
   constructor(properties) {
@@ -20,22 +20,22 @@ export class FtuiChartControls extends FtuiElement {
     this.backwardElement = this.shadowRoot.querySelector('#backward');
     this.forwardElement = this.shadowRoot.querySelector('#forward');
 
-    this.backwardElement.addEventListener('click', () => ftuiHelper.triggerEvent('ftuiBackward', this));
-    this.forwardElement.addEventListener('click', () => ftuiHelper.triggerEvent('ftuiForward', this));
+    this.backwardElement.addEventListener('click', () => triggerEvent('ftuiBackward', this));
+    this.forwardElement.addEventListener('click', () => triggerEvent('ftuiForward', this));
 
     if (this.units) {
       const units = String(this.units).split(/[;,:]/).map(item => item.toLowerCase().trim());
       units.forEach(unit => {
         const element = this.shadowRoot.querySelector('#unit_' + unit);
         element.classList.add('enabled');
-        element.addEventListener('click', () => ftuiHelper.triggerEvent('ftuiUnit' + unit, this));
+        element.addEventListener('click', () => triggerEvent('ftuiUnit' + unit, this));
       });
     }
   }
 
   template() {
     return `
-      <style> @import "components/chart/chart-controls.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <div id="container">
         <div id="controls">
           <span id="backward">◀</span>
@@ -72,24 +72,24 @@ export class FtuiChartControls extends FtuiElement {
 
     switch (this.unit) {
       case 'hour':
-        dateString = ftuiHelper.dateFormat(ftuiHelper.dateFromString(this.startDate), 'ee DD.MM hh:00');
+        dateString = dateFormat(dateFromString(this.startDate), 'ee DD.MM hh:00');
         break;
       case 'day':
       case '24h':
-        dateString = ftuiHelper.dateFormat(ftuiHelper.dateFromString(this.startDate), 'ee DD.MM');
+        dateString = dateFormat(dateFromString(this.startDate), 'ee DD.MM');
         break;
       case 'week': {
-        const endDate = ftuiHelper.dateFromString(this.endDate);
-        endDate.setDate(endDate.getDate()-1);
-        dateString = ftuiHelper.dateFormat(ftuiHelper.dateFromString(this.startDate), 'DD.MM') + ' - ' + ftuiHelper.dateFormat(endDate, 'DD.MM');
+        const endDate = dateFromString(this.endDate);
+        endDate.setDate(endDate.getDate() - 1);
+        dateString = dateFormat(dateFromString(this.startDate), 'DD.MM') + ' - ' + dateFormat(endDate, 'DD.MM');
         break;
       }
       case 'month':
       case '30d':
-        dateString = ftuiHelper.dateFormat(ftuiHelper.dateFromString(this.startDate), 'MM.YYYY');
+        dateString = dateFormat(dateFromString(this.startDate), 'MM.YYYY');
         break;
       case 'year':
-        dateString = ftuiHelper.dateFormat(ftuiHelper.dateFromString(this.startDate), 'YYYY');
+        dateString = dateFormat(dateFromString(this.startDate), 'YYYY');
         break;
     }
     return dateString;

--- a/www/ftui/components/chart/chart.component.js
+++ b/www/ftui/components/chart/chart.component.js
@@ -10,7 +10,7 @@
 import { FtuiElement } from '../element.component.js';
 import { FtuiChartData } from './chart-data.component.js';
 import { Chart } from '../../modules/chart.js/chart.min.js';
-import { dateFormat, getStylePropertyValue } from '../../modules/ftui/ftui.helper.js';
+import { dateFormat, getStylePropertyValue, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 import '../../modules/chart.js/chartjs-adapter-date-fns.bundle.min.js';
 
 const HOUR = 3600 * 1000;
@@ -58,7 +58,7 @@ export class FtuiChart extends FtuiElement {
                 if (resLabel && values && values.length) {
                   resLabel = resLabel.replace(/\$min/g, Math.min(...values));
                   resLabel = resLabel.replace(/\$max/g, Math.max(...values));
-                  resLabel = resLabel.replace(/\$avg/g, values.reduce((a, b) => a + b) / values.length );
+                  resLabel = resLabel.replace(/\$avg/g, values.reduce((a, b) => a + b) / values.length);
                   resLabel = resLabel.replace(/\$last/g, values[values.length - 1]);
                 }
                 return {
@@ -182,7 +182,7 @@ export class FtuiChart extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/chart/chart.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <div id="container">
         <canvas id="chart"></canvas>
       </div>

--- a/www/ftui/components/checkbox/checkbox.component.js
+++ b/www/ftui/components/checkbox/checkbox.component.js
@@ -8,6 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiCheckbox extends FtuiElement {
 
@@ -21,7 +22,7 @@ export class FtuiCheckbox extends FtuiElement {
 
   template() {
     return `
-    <style> @import "components/checkbox/checkbox.component.css"; </style>
+    <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
 
     <span class="checkbox">
       <svg viewBox="0 0 512 512">

--- a/www/ftui/components/content/content.component.js
+++ b/www/ftui/components/content/content.component.js
@@ -8,7 +8,7 @@
 */
 
 import { ftuiApp } from '../../modules/ftui/ftui.app.js';
-import * as ftui from '../../modules/ftui/ftui.helper.js';
+import { log, appendStyleLink, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 import { FtuiElement } from '../element.component.js';
 
 export class FtuiContent extends FtuiElement {
@@ -74,8 +74,8 @@ export class FtuiContent extends FtuiElement {
     this.observer.observe(this.container);
   }
 
-  onIntersectionChange(entries){
-    if(entries[0].isIntersecting) {
+  onIntersectionChange(entries) {
+    if (entries[0].isIntersecting) {
       this.loadFileContent();
     }
   }
@@ -94,10 +94,10 @@ export class FtuiContent extends FtuiElement {
       return this.getAttribute(variable.slice(2, -2)) || '';
     });
     this.innerHTML = solvedContent;
-    ftui.log(2, '[FtuiContent] file loaded and content inserted');
+    log(2, '[FtuiContent] file loaded and content inserted');
     ftuiApp.initComponents(this);
   }
 }
 
-ftui.appendStyleLink('components/content/content.component.css');
+appendStyleLink(getLocalCssPath(import.meta.url));
 window.customElements.define('ftui-content', FtuiContent);

--- a/www/ftui/components/departure/departure.component.js
+++ b/www/ftui/components/departure/departure.component.js
@@ -12,7 +12,7 @@ import { FtuiElement } from '../element.component.js';
 // eslint-disable-next-line no-unused-vars
 import { FtuiIcon } from '../icon/icon.component.js';
 import { fhemService } from '../../modules/ftui/fhem.service.js';
-import { dateFormat, dateFromString, getReadingID } from '../../modules/ftui/ftui.helper.js';
+import { dateFormat, dateFromString, getReadingID, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiDeparture extends FtuiElement {
 
@@ -50,7 +50,7 @@ export class FtuiDeparture extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/departure/departure.component.css";</style>
+      <style> @import "${getLocalCssPath(import.meta.url)}";</style>
       <main>
         <div class="pos">
           <div class="size">

--- a/www/ftui/components/dropdown/dropdown.component.js
+++ b/www/ftui/components/dropdown/dropdown.component.js
@@ -8,6 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiDropdown extends FtuiElement {
   constructor(properties) {
@@ -27,7 +28,7 @@ export class FtuiDropdown extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/dropdown/dropdown.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <select></select>
       <slot></slot>
       `;

--- a/www/ftui/components/element.component.js
+++ b/www/ftui/components/element.component.js
@@ -9,7 +9,6 @@
 
 
 import * as ftuiHelper from '../modules/ftui/ftui.helper.js';
-let ftuiAppMod = await import('../modules/ftui/ftui.app.js');
 
 const uids = {};
 
@@ -33,8 +32,10 @@ export class FtuiElement extends HTMLElement {
       this.createShadowRoot(this.template());
     }
 
-    ftuiAppMod.ftuiApp.attachBinding(this);
-  }
+    if (window.ftuiApp) {
+      ftuiApp.attachBinding(this);
+    }
+ }
 
   createShadowRoot(content) {
     const elemTemplate = document.createElement('template');

--- a/www/ftui/components/element.component.js
+++ b/www/ftui/components/element.component.js
@@ -9,6 +9,7 @@
 
 
 import * as ftuiHelper from '../modules/ftui/ftui.helper.js';
+let ftuiAppMod = await import( '../modules/ftui/ftui.app.js');
 
 const uids = {};
 
@@ -32,9 +33,7 @@ export class FtuiElement extends HTMLElement {
       this.createShadowRoot(this.template());
     }
 
-    if (window.ftuiApp) {
-      ftuiApp.attachBinding(this);
-    }
+    ftuiAppMod.ftuiApp.attachBinding(this);
   }
 
   createShadowRoot(content) {

--- a/www/ftui/components/element.component.js
+++ b/www/ftui/components/element.component.js
@@ -9,7 +9,7 @@
 
 
 import * as ftuiHelper from '../modules/ftui/ftui.helper.js';
-let ftuiAppMod = await import( '../modules/ftui/ftui.app.js');
+let ftuiAppMod = await import('../modules/ftui/ftui.app.js');
 
 const uids = {};
 
@@ -108,7 +108,7 @@ export class FtuiElement extends HTMLElement {
   submitChange(property, value) {
     this.isActiveChange[property] = true;
     this[property] = value;
-    this.emitChangeEvent(property, value );
+    this.emitChangeEvent(property, value);
   }
 
   emitChangeEvent(attribute, value) {

--- a/www/ftui/components/grid/grid-tile.component.js
+++ b/www/ftui/components/grid/grid-tile.component.js
@@ -8,6 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiGridTile extends FtuiElement {
 
@@ -19,7 +20,7 @@ export class FtuiGridTile extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/grid/grid-tile.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
     <slot name="header"></slot>
     <div class="content">
       <slot></slot>

--- a/www/ftui/components/grid/grid-tile.component.js
+++ b/www/ftui/components/grid/grid-tile.component.js
@@ -12,8 +12,15 @@ import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiGridTile extends FtuiElement {
 
-  constructor(properties) {
-    super(Object.assign(FtuiGridTile.properties, properties));
+  constructor() {
+    const properties = {
+      row: 0,
+      col: 0,
+      height: 0,
+      width: 0,
+      color: '',
+    };
+    super(properties);
 
     const header = this.querySelector('header, ftui-grid-header');
     header && header.setAttribute('slot', 'header');
@@ -25,20 +32,6 @@ export class FtuiGridTile extends FtuiElement {
     <div class="content">
       <slot></slot>
     </div>`;
-  }
-
-  static get properties() {
-    return {
-      row: 0,
-      col: 0,
-      height: 0,
-      width: 0,
-      color: ''
-    };
-  }
-
-  static get observedAttributes() {
-    return [...this.convertToAttributes(FtuiGridTile.properties), ...super.observedAttributes];
   }
 }
 

--- a/www/ftui/components/grid/grid-tile.component.js
+++ b/www/ftui/components/grid/grid-tile.component.js
@@ -11,15 +11,8 @@ import { FtuiElement } from '../element.component.js';
 
 export class FtuiGridTile extends FtuiElement {
 
-  constructor() {
-    const properties = {
-      row: 0,
-      col: 0,
-      height: 0,
-      width: 0,
-      color: '',
-    };
-    super(properties);
+  constructor(properties) {
+    super(Object.assign(FtuiGridTile.properties, properties));
 
     const header = this.querySelector('header, ftui-grid-header');
     header && header.setAttribute('slot', 'header');
@@ -31,6 +24,20 @@ export class FtuiGridTile extends FtuiElement {
     <div class="content">
       <slot></slot>
     </div>`;
+  }
+
+  static get properties() {
+    return {
+      row: 0,
+      col: 0,
+      height: 0,
+      width: 0,
+      color: ''
+    };
+  }
+
+  static get observedAttributes() {
+    return [...this.convertToAttributes(FtuiGridTile.properties), ...super.observedAttributes];
   }
 }
 

--- a/www/ftui/components/grid/grid.component.js
+++ b/www/ftui/components/grid/grid.component.js
@@ -29,7 +29,7 @@ export class FtuiGrid extends FtuiElement {
     this.debouncedResize = debounce(this.configureGrid, this);
 
     this.windowWidth = 0;
-    this.tiles = this.querySelectorAll('ftui-grid-tile');
+    this.tiles = this.querySelectorAll('ftui-grid-tile, .ftui-grid-tile');
 
 
     if (this.responsive) {

--- a/www/ftui/components/grid/grid.component.js
+++ b/www/ftui/components/grid/grid.component.js
@@ -29,7 +29,7 @@ export class FtuiGrid extends FtuiElement {
     this.debouncedResize = debounce(this.configureGrid, this);
 
     this.windowWidth = 0;
-    this.tiles = this.querySelectorAll('ftui-grid-tile, .ftui-grid-tile');
+    this.tiles = this.querySelectorAll('ftui-grid-tile');
 
 
     if (this.responsive) {

--- a/www/ftui/components/icon/icon.component.js
+++ b/www/ftui/components/icon/icon.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import { isNumeric } from '../../modules/ftui/ftui.helper.js';
+import { isNumeric, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 const sizes = [0.25, 0.375, 0.5, 0.625, 0.75, 0.875, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 3.5, 4, 6, 8];
 const cache = {};
@@ -22,7 +22,7 @@ export class FtuiIcon extends FtuiElement {
 
   template() {
     return `
-        <style> @import "components/icon/icon.component.css"; </style>
+        <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
         <span class="icon"></span>
         <slot></slot>
       `;

--- a/www/ftui/components/knob/knob.component.js
+++ b/www/ftui/components/knob/knob.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import { countDecimals, round, limit, scale } from '../../modules/ftui/ftui.helper.js';
+import { countDecimals, round, limit, scale, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 
 export class FtuiKnob extends FtuiElement {
@@ -71,7 +71,7 @@ export class FtuiKnob extends FtuiElement {
 
   template() {
     return `
-    <style> @import "components/knob/knob.component.css"</style>
+    <style> @import "${getLocalCssPath(import.meta.url)}"</style>
     <svg class="svg" height="${this.height}" width="${this.width}" focusable="false">
    
     <defs>

--- a/www/ftui/components/medialist/medialist.component.js
+++ b/www/ftui/components/medialist/medialist.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import { isDefined, durationFromSeconds, log, error, isNumeric } from '../../modules/ftui/ftui.helper.js';
+import { isDefined, durationFromSeconds, log, error, isNumeric, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 import { parseHocon } from '../../modules/hocon/hocon.min.js';
 
 export class FtuiMedialist extends FtuiElement {
@@ -21,7 +21,7 @@ export class FtuiMedialist extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/medialist/medialist.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <div class="media-list">
         <div class="media placeholder">
           <div class="media-image"></div>

--- a/www/ftui/components/menu/menu.component.js
+++ b/www/ftui/components/menu/menu.component.js
@@ -10,6 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiMenu extends FtuiElement {
 
@@ -21,7 +22,7 @@ export class FtuiMenu extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/menu/menu.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
     <div class="box-menu"><slot></slot></div>`;
   }
 

--- a/www/ftui/components/meter/meter.component.js
+++ b/www/ftui/components/meter/meter.component.js
@@ -10,7 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import { limit, scale } from '../../modules/ftui/ftui.helper.js';
+import { limit, scale, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiMeter extends FtuiElement {
 
@@ -27,7 +27,7 @@ export class FtuiMeter extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/meter/meter.component.css";</style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}";</style>
             <div class="container">
               <slot></slot>
               <div class="progress">

--- a/www/ftui/components/popup/popup.component.js
+++ b/www/ftui/components/popup/popup.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import * as ftui from '../../modules/ftui/ftui.helper.js';
+import { triggerEvent, getLocalCssPath} from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiPopup extends FtuiElement {
 
@@ -30,7 +30,7 @@ export class FtuiPopup extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/popup/popup.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <style> 
         .overlay {
           position: fixed;
@@ -129,7 +129,7 @@ export class FtuiPopup extends FtuiElement {
   setState(value) {
     if (value) {
       this.removeAttribute('hidden');
-      ftui.triggerEvent('ftuiVisibilityChanged');
+      triggerEvent('ftuiVisibilityChanged');
       this.startTimeout();
     } else {
       this.setAttribute('hidden', '');

--- a/www/ftui/components/rotor/rotor.component.js
+++ b/www/ftui/components/rotor/rotor.component.js
@@ -8,6 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 class FtuiRotor extends FtuiElement {
 
@@ -21,7 +22,7 @@ class FtuiRotor extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/rotor/rotor.component.css"</style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"</style>
       <slot></slot>
       `;
   }

--- a/www/ftui/components/segment/segment.component.js
+++ b/www/ftui/components/segment/segment.component.js
@@ -10,7 +10,7 @@
 import { FtuiElement } from '../element.component.js';
 // eslint-disable-next-line no-unused-vars
 import { FtuiSegmentButton } from './segment-button.component.js';
-import { getStylePropertyValue } from '../../modules/ftui/ftui.helper.js';
+import { getStylePropertyValue, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 class FtuiSegment extends FtuiElement {
 
@@ -27,7 +27,7 @@ class FtuiSegment extends FtuiElement {
 
   template() {
     return `
-    <style> @import "components/segment/segment.component.css"; </style>
+    <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
 		<div class="segments">
 			<span class="selection"></span>
 			<slot></slot>

--- a/www/ftui/components/slider/slider.component.js
+++ b/www/ftui/components/slider/slider.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import * as ftui from '../../modules/ftui/ftui.helper.js';
+import { isVisible, getLocalCssPath, getModulesPath } from '../../modules/ftui/ftui.helper.js';
 import { Rangeable } from '../../modules/rangeable/rangeable.min.js';
 
 
@@ -40,7 +40,7 @@ export class FtuiSlider extends FtuiElement {
 
     // force re-render if visible
     document.addEventListener('ftuiVisibilityChanged', () => {
-      if (ftui.isVisible(this)) {
+      if (isVisible(this)) {
         this.rangeable.update();
       }
     }, false);
@@ -58,8 +58,8 @@ export class FtuiSlider extends FtuiElement {
 
   template() {
     return `
-    <style> @import "modules/rangeable/rangeable.min.css"; </style>
-    <style> @import "components/slider/slider.component.css"; </style>
+    <style> @import "${getModulesPath('rangeable/rangeable.min.css')}"; </style>
+    <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
 
     <div class="wrapper">
       <input type="range" orient="vertical">

--- a/www/ftui/components/swiper/swiper.component.js
+++ b/www/ftui/components/swiper/swiper.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
-import { createElement } from '../../modules/ftui/ftui.helper.js';
+import { createElement, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 class FtuiSwiper extends FtuiElement {
 
@@ -24,7 +24,7 @@ class FtuiSwiper extends FtuiElement {
 
   template() {
     return `
-      <style> @import "components/swiper/swiper.component.css"; </style>
+      <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
       <div class="slides">
         <slot></slot>
       </div>

--- a/www/ftui/components/switch/switch.component.js
+++ b/www/ftui/components/switch/switch.component.js
@@ -8,6 +8,7 @@
 */
 
 import { FtuiCheckbox } from '../checkbox/checkbox.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiSwitch extends FtuiCheckbox {
 
@@ -24,7 +25,7 @@ export class FtuiSwitch extends FtuiCheckbox {
 
   template() {
     return `
-    <style> @import "components/switch/switch.component.css"; </style>
+    <style> @import "${getLocalCssPath(import.meta.url)}"; </style>
 
       <span class="checkbox">
           <span class="inner"></span>

--- a/www/ftui/components/tab/tab.component.js
+++ b/www/ftui/components/tab/tab.component.js
@@ -8,7 +8,7 @@
 */
 
 import { FtuiButton } from '../button/button.component.js';
-import { selectAll, selectOne, triggerEvent } from '../../modules/ftui/ftui.helper.js';
+import { selectAll, selectOne, triggerEvent, getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 /* eslint-disable no-unused-vars */
 import { FtuiTabView } from './tab-view.component.js';
 import { FtuiTabTitle} from './tab-title.component.js';
@@ -29,7 +29,7 @@ class FtuiTab extends FtuiButton {
   }
 
   template() {
-    return `<style> @import "components/tab/tab.component.css"; </style>`
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>`
       + super.template();
   }
 

--- a/www/ftui/components/view/view-item.component.js
+++ b/www/ftui/components/view/view-item.component.js
@@ -10,6 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiViewItem extends FtuiElement {
 
@@ -26,7 +27,7 @@ export class FtuiViewItem extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/view/view-item.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
             <div class="content">
               <slot name="start"></slot>
               <div class="inner">

--- a/www/ftui/components/view/view-section.component.js
+++ b/www/ftui/components/view/view-section.component.js
@@ -10,6 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiViewSection extends FtuiElement {
 
@@ -18,7 +19,7 @@ export class FtuiViewSection extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/view/view-section.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
             <div class="header">
               <slot name="header"></slot>
             </div>         

--- a/www/ftui/components/view/view-sheet.component.js
+++ b/www/ftui/components/view/view-sheet.component.js
@@ -10,6 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiViewSheet extends FtuiElement {
 
@@ -20,7 +21,7 @@ export class FtuiViewSheet extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/view/view-sheet.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
             <div class="content">
 
                   <slot></slot>

--- a/www/ftui/components/view/view-toolbar.component.js
+++ b/www/ftui/components/view/view-toolbar.component.js
@@ -10,6 +10,7 @@
 */
 
 import { FtuiElement } from '../element.component.js';
+import { getLocalCssPath } from '../../modules/ftui/ftui.helper.js';
 
 export class FtuiViewToolbar extends FtuiElement {
 
@@ -18,7 +19,7 @@ export class FtuiViewToolbar extends FtuiElement {
   }
 
   template() {
-    return `<style> @import "components/view/view-toolbar.component.css"; </style>
+    return `<style> @import "${getLocalCssPath(import.meta.url)}"; </style>
             <div class="container">
               <div class="link left">
                 <slot name="start"></slot>

--- a/www/ftui/components/weather/weather.component.js
+++ b/www/ftui/components/weather/weather.component.js
@@ -20,7 +20,7 @@ class FtuiWeather extends FtuiIcon {
   static get properties() {
     return {
       provider: 'proplanta',
-      iconSet: 'meteocons',
+      iconset: 'meteocons',
       condition: '',
       name: '', // base class property (icon)
       rgb: '', // base class property (icon)
@@ -35,7 +35,7 @@ class FtuiWeather extends FtuiIcon {
     switch (name) {
       case 'condition': {
         const conditions = providerSet[this.provider] || {};
-        const icons = iconSet[this.iconSet] || {};
+        const icons = iconSet[this.iconset] || {};
         this.loadIcon(icons[conditions[newValue]] || 'icons/none.svg');
         break;
       }

--- a/www/ftui/modules/ftui/ftui.app.js
+++ b/www/ftui/modules/ftui/ftui.app.js
@@ -16,7 +16,7 @@ class FtuiApp {
       toastPosition: 'bottomLeft',
       toastDuration: 5,
       styleList: [
-        'modules/vanilla-notify/vanilla-notify.css',
+        ftui.getModulesPath( 'vanilla-notify/vanilla-notify.css')
       ],
     };
     this.states = {

--- a/www/ftui/modules/ftui/ftui.helper.js
+++ b/www/ftui/modules/ftui/ftui.helper.js
@@ -103,6 +103,22 @@ export function getFilteredStepKeys(map, searchKey) {
   }
 }
 
+
+// Path calculation functions
+
+export function getLocalCssPath(inClassFileUrl, inFileName = null) {
+  console.log("getLocalCssPath: " + ((new URL(inClassFileUrl)).pathname.replace(/.js$/, '.css')));
+  if (inFileName == null)
+    return ((new URL(inClassFileUrl)).pathname.replace(/.js$/, '.css'));
+  else
+    return ((new URL(inFileName, inClassFileUrl)).pathname);
+}
+
+export function getModulesPath(inRelPath = '') {
+  return ((new URL('../' + inRelPath, import.meta.url)).pathname);
+}
+
+
 // DOM functions
 
 export function appendStyleLink(file) {

--- a/www/ftui/modules/ftui/ftui.helper.js
+++ b/www/ftui/modules/ftui/ftui.helper.js
@@ -107,7 +107,6 @@ export function getFilteredStepKeys(map, searchKey) {
 // Path calculation functions
 
 export function getLocalCssPath(inClassFileUrl, inFileName = null) {
-  console.log("getLocalCssPath: " + ((new URL(inClassFileUrl)).pathname.replace(/.js$/, '.css')));
   if (inFileName == null)
     return ((new URL(inClassFileUrl)).pathname.replace(/.js$/, '.css'));
   else


### PR DESCRIPTION
At the moment FTUI requires a certain position of the html files inside the FTUI tree.
Eg. what works is the following hierarchy:
 
+ FTUI
    + components
    + modules
    + ...
    + mobile.html (my own file)

What I want to have is:

+ FTUI
   + ... (untouched)
+ HR (my dir)
  + mobile.html
  + ... (my other stuff)

I want to be able to decouple that, so can use the FTUI tree as is, placing my html files (or internal extensions) outside of the FTUI tree.
Main reasons for this not being possible today are fixed paths in the code for loading the component specific CSS files.
Having a central config variable would have been one solution.
This pull request calculates these paths dynamically, so even a config variable is not needed.
