### PR TITLE
patch for basic auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ docker pull knowthelist/ftui
 - Put the <b>fhemweb_url</b> into the head of the index.html: 
 ````
 <meta name="fhemweb_url" content="http://<your_fhem_url>:8083/fhem/">
+<meta name="username" content="your user">
+<meta name="password" content="your password">
 ````
 
 - <b>Run</b> the container: 

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,7 +391,7 @@ class FhemService {
   }
 
   fetchCSrf() {
-    const headers = new Headers();
+    const myHeaders = new Headers();
     myHeaders.append("Authorization", "Basic " + btoa(this.config.username + ':' + this.config.password) );
     const options = {
       headers: myHeaders,

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -392,6 +392,17 @@ class FhemService {
       }
     })
   }
+  
+  getCookie(cookie, name) {
+    const q = {}
+    cookie?.replace(/\s/g, '')
+      .split(';')
+      .map(i=>i.split('='))
+      .forEach(([key, value]) => {
+        q[key] = value
+    })
+    return q[name]??null;
+  }
 
   fetchCSrf() {
     const myHeaders = new Headers();
@@ -403,7 +414,7 @@ class FhemService {
     };
     return fetch(this.config.fhemDir + '?XHR=1', options ) 
         .then(response => {
-          this.config.csrf = response.headers.get('X-FHEM-csrfToken');
+          this.config.csrf = getCookie(response.headers.get('set-cookie'),'AuthToken');
           log(1, 'Got csrf from FHEM:' + this.config.csrf);
         });
   }

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -392,7 +392,7 @@ class FhemService {
 
   fetchCSrf() {
     const options = {
-      headers: new Headers('Authorization', 'Basic ' + base64.encode(this.config.username + ':' + this.config.password)),
+      headers: new Headers('Authorization', 'Basic ' + btoa(this.config.username + ':' + this.config.password)),
       cache: 'no-cache'
     };
     return fetch(this.config.fhemDir + '?XHR=1', options)

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -414,7 +414,7 @@ class FhemService {
     };
     return fetch(this.config.fhemDir + '?XHR=1', options ) 
         .then(response => {
-          this.config.csrf = getCookie(response.headers.get('set-cookie'),'AuthToken');
+          this.config.csrf = this.getCookie(response.headers.get('set-cookie'),'AuthToken');
           log(1, 'Got csrf from FHEM:' + this.config.csrf);
         });
   }

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -395,7 +395,8 @@ class FhemService {
     myHeaders.append("Authorization", "Basic " + btoa(this.config.username + ':' + this.config.password) );
     const options = {
       headers: myHeaders,
-      cache: 'no-cache'
+      cache: 'no-cache',
+      mode: 'cors'
     };
     return fetch(this.config.fhemDir + '?XHR=1', options ) 
         .then(response => {

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,9 +391,11 @@ class FhemService {
   }
 
   fetchCSrf() {
-    return fetch(this.config.fhemDir + '?XHR=1', {
-      cache: 'no-cache',
-    })
+    const options = {
+      headers: new Headers('Authorization', 'Basic ' + base64.encode(this.config.username + ':' + this.config.password)),
+      cache: 'no-cache'
+    };
+    return fetch(this.config.fhemDir + '?XHR=1', options)
       .then(response => {
         this.config.csrf = response.headers.get('X-FHEM-csrfToken');
         log(1, 'Got csrf from FHEM:' + this.config.csrf);

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,12 +391,9 @@ class FhemService {
   }
 
   fetchCSrf() {
-    const options = {
-      username: this.config.username,
-      password: this.config.password,
-      cache: 'no-cache'
-    };
-    return fetch(this.config.fhemDir + '?XHR=1', options)
+    return fetch(this.config.fhemDir + '?XHR=1', {
+      cache: 'no-cache',
+    })
       .then(response => {
         this.config.csrf = response.headers.get('X-FHEM-csrfToken');
         log(1, 'Got csrf from FHEM:' + this.config.csrf);

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,9 +391,12 @@ class FhemService {
   }
 
   fetchCSrf() {
-    return fetch(this.config.fhemDir + '?XHR=1', {
-      cache: 'no-cache',
-    })
+    const options = {
+      username: this.config.username,
+      password: this.config.password,
+      cache: 'no-cache'
+    };
+    return fetch(this.config.fhemDir + '?XHR=1', options)
       .then(response => {
         this.config.csrf = response.headers.get('X-FHEM-csrfToken');
         log(1, 'Got csrf from FHEM:' + this.config.csrf);

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,10 +391,14 @@ class FhemService {
   }
 
   fetchCSrf() {
-    return fetch(this.config.fhemDir + '?XHR=1', { 
-	    headers: new Headers({ 'Authorization' : 'Basic ' + btoa(this.config.username + ':' + this.config.password) }),
-            cache: 'no-cache' 
-        }).then(response => {
+    const headers = new Headers();
+    myHeaders.append("Authorization", "Basic " + btoa(this.config.username + ':' + this.config.password) );
+    const options = {
+      headers: myHeaders,
+      cache: 'no-cache'
+    };
+    return fetch(this.config.fhemDir + '?XHR=1', options ) 
+        .then(response => {
           this.config.csrf = response.headers.get('X-FHEM-csrfToken');
           log(1, 'Got csrf from FHEM:' + this.config.csrf);
         });

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -359,9 +359,12 @@ class FhemService {
       fwcsrf: this.config.csrf,
       XHR: '1',
     };
+    const myHeaders = new Headers();
+    myHeaders.append("Authorization", "Basic " + btoa(this.config.username + ':' + this.config.password) );
     const options = {
-      username: this.config.username,
-      password: this.config.password,
+      headers: myHeaders,
+      cache: 'no-cache',
+      mode: 'cors'
     };
     url.search = new URLSearchParams(params)
     log(1, '[fhemService] send to FHEM: ' + cmdline);

--- a/www/ftui/modules/ftui/fhem.service.js
+++ b/www/ftui/modules/ftui/fhem.service.js
@@ -391,15 +391,13 @@ class FhemService {
   }
 
   fetchCSrf() {
-    const options = {
-      headers: new Headers('Authorization', 'Basic ' + btoa(this.config.username + ':' + this.config.password)),
-      cache: 'no-cache'
-    };
-    return fetch(this.config.fhemDir + '?XHR=1', options)
-      .then(response => {
-        this.config.csrf = response.headers.get('X-FHEM-csrfToken');
-        log(1, 'Got csrf from FHEM:' + this.config.csrf);
-      });
+    return fetch(this.config.fhemDir + '?XHR=1', { 
+	    headers: new Headers({ 'Authorization' : 'Basic ' + btoa(this.config.username + ':' + this.config.password) }),
+            cache: 'no-cache' 
+        }).then(response => {
+          this.config.csrf = response.headers.get('X-FHEM-csrfToken');
+          log(1, 'Got csrf from FHEM:' + this.config.csrf);
+        });
   }
 
   scheduleHealthCheck() {


### PR DESCRIPTION
Hi there,

Not sure if I'm missing something here, even though there was existing code refering to username and password, it did not work for me.  Granted, I'm running ftui behind traefik and authelia, though with a bypass on authelia.

FYI, for traefik I needed to configure the below middleware since my fhem instance is also behind traefik as https://fhem.XXX.YYY and tui under a difference domain, https://ftui.XXX.YYY. This had cors screaming all over the place, hence the middleware below.


Cheers,
Paulo

**traefik.yml**
```
middlewares:
    fhem-cors-headers:
      headers:
        accessControlAllowCredentials: true
        accessControlAllowHeaders:
          - Origin
          - Authorization
          - Content-Type
        accessControlAllowMethods:
          - GET
          - OPTIONS
          - PUT
        accessControlAllowOriginList:
          - https://ftui.XXX.YYY
        accessControlMaxAge: 100
http:
  routers:
   fhem:
      service: service-fhem
      entrypoints:
        - websecure
      middlewares:
        - secured
        - fhem-cors-headers
      rule: "Host(`fhem.XXX.YYY`)"
      tls:
        true
services:
    service-fhem:
      loadBalancer:
        servers:
        - url: "https://server-name.XXX.YYY:8083/"
```



