### PR TITLE
Optimizes the loading time of charts #2

### DIFF
--- a/www/ftui/components/chart/chart-data.component.js
+++ b/www/ftui/components/chart/chart-data.component.js
@@ -64,7 +64,9 @@ export class FtuiChartData extends FtuiElement {
 
   fetch() {
     if (!this.isLoading) {
-      this.fetchLogItems(this.log, this.file, this.spec);
+      if (ftuiHelper.isVisible(this)){
+        this.fetchLogItems(this.log, this.file, this.spec);
+      }
     }
   }
 

--- a/www/ftui/modules/ftui/ftui.helper.js
+++ b/www/ftui/modules/ftui/ftui.helper.js
@@ -160,7 +160,13 @@ export function isAppVisible() {
 }
 
 export function isVisible(element) {
-  return (element.offsetParent !== null);
+  const pop_parent = element.closest('ftui-popup');
+  if (pop_parent){
+    return (pop_parent.offsetParent !== null);
+  } else {
+    return (element.offsetParent !== null);
+  }
+  
 }
 
 export function isDefined(value) {


### PR DESCRIPTION
Ich habe nun nach längerer Zeit ein Update von FTUI gemacht. Dabei ist mir aufgefallen, das nicht alle Änderungen übernommen worden sind, um ein laden der Charts zu verhindern, wenn diese nicht sichtbar sind.
Charts in Popups laden derzeit weiterhin.

Ich habe diesmal in der ftui.helper.js die Anpassung vorgenommen, das ein visible auch in einem Popup richtig zurück gegeben wird. 

Durch die Prüfung in chart-data.component.js wird verhindert, das bei einer Aktualisierung der Daten ein Laden erfolgt.

Danke für die Arbeit an FTUI 3 !