### PR TITLE
Fix scale function in ftui.helper.js

### DIFF
--- a/www/ftui/modules/ftui/ftui.helper.js
+++ b/www/ftui/modules/ftui/ftui.helper.js
@@ -423,9 +423,18 @@ export function formatMoney(amount) {
 }
 
 export function scale(value, minIn, maxIn, minOut, maxOut) {
-  const slope = (minOut - maxOut) / (minIn - maxIn);
-  const intercept = slope * -(minIn) + minOut;
-  return value * slope + intercept;
+  if(value <= minIn) {
+	  return minOut;
+  }
+  else if(value >= maxIn) {
+	  return maxOut;
+  }
+  else
+  {	  
+	const slope = (minOut - maxOut) / (minIn - maxIn);
+	const intercept = slope * -(minIn) + minOut;
+	return value * slope + intercept;
+  }
 }
 
 export function limit(value, minIn, maxIn) {


### PR DESCRIPTION
The current scale implementation can lead to return values beyond min/max being specified when the value is out of bounds.

This commit ensures that the boundaries are kept:
```
export function scale(value, minIn, maxIn, minOut, maxOut) {
  if(value <= minIn) {
	  return minOut;
  }
  else if(value >= maxIn) {
	  return maxOut;
  }
  else
  {	  
	const slope = (minOut - maxOut) / (minIn - maxIn);
	const intercept = slope * -(minIn) + minOut;
	return value * slope + intercept;
  }
}
```