### PR TITLE
Add support for Netatmo forecast symbols

### DIFF
--- a/www/ftui/components/weather/weather.component.js
+++ b/www/ftui/components/weather/weather.component.js
@@ -34,9 +34,14 @@ class FtuiWeather extends FtuiIcon {
   onAttributeChanged(name, newValue) {
     switch (name) {
       case 'condition': {
-        const conditions = providerSet[this.provider] || {};
+        const provider = providerSet[this.provider];
         const icons = iconSet[this.iconSet] || {};
-        this.loadIcon(icons[conditions[newValue]] || 'icons/none.svg');
+
+        const condition = typeof provider === 'function'
+          ? provider(newValue)
+          : provider?.[newValue];
+
+        this.loadIcon(icons[condition] || 'icons/none.svg');
         break;
       }
       default:

--- a/www/ftui/components/weather/weather.map.js
+++ b/www/ftui/components/weather/weather.map.js
@@ -5,7 +5,95 @@
   SCATTERED_THUNDERSTORM, NA, CLEAR
 */
 
+/**
+ * Converts a six-digit Netatmo weather symbol into one of FTUI's
+ * 19 intermediate weather conditions.
+ *
+ * Digit layout:
+ * 1: celestial body (1 = sun, 2 = moon, 3 = neutral)
+ * 2: cloud intensity
+ * 3: rain intensity
+ * 4: snow intensity
+ * 5: hail intensity
+ * 6: special condition
+ */
+export function decodeNetatmoSymbol(value) {
+  const code = String(value ?? '').trim();
+
+  if (!/^\d{6}$/.test(code)) {
+    return 'NA';
+  }
+
+  const [
+    celestial,
+    clouds,
+    rain,
+    snow,
+    hail,
+    special,
+  ] = [...code].map(Number);
+
+  // Lightning has the highest priority.
+  if (special === 1) {
+    return 'THUNDERSTORM';
+  }
+
+  if (special === 3) {
+    return 'FOGGY';
+  }
+
+  // Warning and flood have no matching FTUI condition.
+  if (special === 2 || special === 5) {
+    return 'NA';
+  }
+
+  // Mixed rain and snow.
+  if (rain > 0 && snow > 0) {
+    return 'RAIN_SNOW';
+  }
+
+  // Snow and hail.
+  if (snow > 0 || hail > 0) {
+    return snow === 1 && hail === 0
+      ? 'SNOW_SHOWER'
+      : 'SNOW';
+  }
+
+  // Rain intensity.
+  if (rain === 1) {
+    return 'LIGHT_SHOWERS';
+  }
+
+  if (rain >= 2) {
+    return 'SHOWERS';
+  }
+
+  // Wind has no dedicated FTUI intermediate condition.
+  if (special === 4) {
+    return 'CLOUDY';
+  }
+
+  // Dry weather: map cloud intensity.
+  switch (clouds) {
+    case 0:
+      return celestial === 3 ? 'CLEAR' : 'CLOUDLESS';
+
+    case 1:
+      return celestial === 3 ? 'CLOUDY' : 'FAIR';
+
+    case 2:
+      return celestial === 3 ? 'CLOUDY' : 'PARTLY_CLOUDY';
+
+    case 3:
+      return celestial === 3 ? 'OVERCAST' : 'MOSTLY_CLOUDY';
+
+    default:
+      return 'NA';
+  }
+}
+
 export const providerSet = {
+  netatmo: decodeNetatmoSymbol,
   proplanta: {
     wolkenlos: 'CLOUDLESS',
     sonnig: 'SUNNY',


### PR DESCRIPTION
This PR adds support for Netatmo forecast symbols to the FTUI weather component.

Changes:
* add a Netatmo forecast decoder
* allow provider functions in addition to static lookup tables
* map Netatmo forecast symbols to the existing FTUI intermediate weather conditions

The implementation is fully backwards compatible.
Existing weather providers and icon sets continue to work unchanged.

Tested with:
* Netatmo forecast provider
* Meteocons icon set

The implementation only extends the provider handling.
No existing providers or icon mappings are modified.